### PR TITLE
Normalize autoloader assignment spacing

### DIFF
--- a/src/includes/Autoloader.php
+++ b/src/includes/Autoloader.php
@@ -33,7 +33,7 @@ final class Autoloader {
 	 * @return void
 	 */
 	public static function register( $prefix, $base_dir ) {
-		self::$prefix   = rtrim( $prefix, '\\' ) . '\\';
+		self::$prefix = rtrim( $prefix, '\\' ) . '\\';
 		self::$base_dir = rtrim( $base_dir, DIRECTORY_SEPARATOR ) . DIRECTORY_SEPARATOR;
 
 		spl_autoload_register( array( __CLASS__, 'autoload' ) );
@@ -51,9 +51,9 @@ final class Autoloader {
 			return;
 		}
 
-		$relative		= substr( $class, strlen( self::$prefix ) );
-		$relative_path	= str_replace( '\\', DIRECTORY_SEPARATOR, $relative ) . '.php';
-		$file			= self::$base_dir . $relative_path;
+		$relative = substr( $class, strlen( self::$prefix ) );
+		$relative_path = str_replace( '\\', DIRECTORY_SEPARATOR, $relative ) . '.php';
+		$file = self::$base_dir . $relative_path;
 
 		if ( is_readable( $file ) ) {
 			require_once $file;


### PR DESCRIPTION
## Summary
- ensure autoloader assignments use single spaces around the equals operator to satisfy WordPress.WhiteSpace.OperatorSpacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d7bfbde1908321813a64963d95a0ce