### PR TITLE
Remove void return types for PHP 7.0 compatibility

### DIFF
--- a/src/includes/Assets/Assets.php
+++ b/src/includes/Assets/Assets.php
@@ -18,20 +18,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Assets {
 
-	/**
-	 * Register WordPress hooks.
-	 */
-	public function register_hooks(): void {
+       /**
+        * Register WordPress hooks.
+        *
+        * @return void
+        */
+       public function register_hooks() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_assets' ), 10 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'public_assets' ) );
 	}
 
-	/**
-	 * Enqueue admin assets for the plugin settings screen.
-	 *
-	 * @param string $hook_suffix Current admin page hook suffix.
-	 */
-	public function admin_assets( string $hook_suffix ): void {
+       /**
+        * Enqueue admin assets for the plugin settings screen.
+        *
+        * @param string $hook_suffix Current admin page hook suffix.
+        * @return void
+        */
+       public function admin_assets( string $hook_suffix ) {
 		if ( 'toplevel_page_consent-pilot' !== $hook_suffix ) {
 			return;
 		}
@@ -53,10 +56,12 @@ class Assets {
 		);
 	}
 
-	/**
-	 * Enqueue public assets and inject dynamic styles and data.
-	 */
-	public function public_assets(): void {
+       /**
+        * Enqueue public assets and inject dynamic styles and data.
+        *
+        * @return void
+        */
+       public function public_assets() {
 		$custom_css = '
 		.consentpilot {
 			--accent: ' . esc_html( Settings::$options['color_accent'] ) . ';

--- a/src/includes/PublicSite/PublicSite.php
+++ b/src/includes/PublicSite/PublicSite.php
@@ -25,7 +25,7 @@ class PublicSite {
 	 *
 	 * @return void
 	 */
-	public function register_hooks(): void {
+        public function register_hooks() {
 		// Add public-facing hooks as needed.
 		if ( ! is_admin() ) {
 			add_action( 'wp_footer', array( $this, 'consent_notice' ) );
@@ -37,7 +37,7 @@ class PublicSite {
 	 *
 	 * @return void
 	 */
-	public function consent_notice(): void {
+        public function consent_notice() {
 		$privacy_policy = get_privacy_policy_url();
 		?>
 		<!-- ===== Banner ===== -->

--- a/src/includes/REST/RESTController.php
+++ b/src/includes/REST/RESTController.php
@@ -26,7 +26,7 @@ class RESTController {
 	 *
 	 * @return void
 	 */
-	public function register_hooks(): void {
+        public function register_hooks() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
@@ -35,7 +35,7 @@ class RESTController {
 	 *
 	 * @return void
 	 */
-	public function register_routes(): void {
+        public function register_routes() {
 		register_rest_route(
 			'consent-pilot/v1',
 			'consent',

--- a/src/includes/Settings/Settings.php
+++ b/src/includes/Settings/Settings.php
@@ -38,10 +38,12 @@ class Settings {
 	 */
 	public static $options;
 
-	/**
-	 * Initialize defaults and load saved options.
-	 */
-	public static function init(): void {
+        /**
+         * Initialize defaults and load saved options.
+         *
+         * @return void
+         */
+        public static function init() {
 		self::$default['consent_notice'] = __( 'We use cookies to enhance your experience, analyze traffic, and personalize content. You can accept all cookies, reject non-essential ones, or manage preferences.', 'consent-pilot' );
 
 		// Load saved options or fall back to defaults.
@@ -51,18 +53,22 @@ class Settings {
 		}
 	}
 
-	/**
-	 * Register WP hooks.
-	 */
-	public function register_hooks(): void {
+        /**
+         * Register WP hooks.
+         *
+         * @return void
+         */
+        public function register_hooks() {
 		self::init();
 		add_action( 'admin_init', array( $this, 'register' ) );
 	}
 
-	/**
-	 * Register settings, sections, and fields.
-	 */
-	public function register(): void {
+        /**
+         * Register settings, sections, and fields.
+         *
+         * @return void
+         */
+        public function register() {
 
 		register_setting(
 			CONSENTPILOT_PREFIX,	 // Option group.
@@ -84,7 +90,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_gtm',
 			__( 'GTM container ID', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				?>
 				<input
 					type="text"
@@ -104,7 +113,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_log_ip',
 			__( 'Log settings', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				$checked = (int) ( self::$options['log_ip'] ?? 0 );
 				?>
 				<label for="consentpilot_log_ip">
@@ -125,7 +137,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_consent_notice',
 			__( 'Consent notice text', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				$val = (string) ( self::$options['consent_notice'] ?? self::$default['consent_notice'] );
 				?>
 				<textarea
@@ -141,7 +156,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_consent_validity',
 			__( 'Consent validity', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				?>
 				<input
 					type="number"
@@ -164,7 +182,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_enable_darkmode',
 			__( 'Dark mode settings', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				$checked = (int) ( self::$options['enable_darkmode'] ?? 0 );
 				?>
 				<label for="consentpilot_enable_darkmode">
@@ -185,7 +206,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_color_accent',
 			__( 'Accent color', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				$val     = (string) ( self::$options['color_accent'] ?? self::$default['color_accent'] );
 				$default = (string) self::$default['color_accent'];
 				?>
@@ -204,7 +228,10 @@ class Settings {
 		add_settings_field(
 			'consentpilot_color_url',
 			__( 'Link color', 'consent-pilot' ),
-			function (): void {
+                        /**
+                         * @return void
+                         */
+                        function () {
 				$val     = (string) ( self::$options['color_url'] ?? self::$default['color_url'] );
 				$default = (string) self::$default['color_url'];
 				?>

--- a/src/includes/Shortcodes/Shortcodes.php
+++ b/src/includes/Shortcodes/Shortcodes.php
@@ -23,7 +23,7 @@ class Shortcodes {
 	 *
 	 * @return void
 	 */
-	public function register_hooks(): void {
+        public function register_hooks() {
 		add_shortcode( 'consentpilot-preferences', array( $this, 'render' ) );
 	}
 


### PR DESCRIPTION
## Summary
- remove PHP 7.1-only `void` return type hints from public API and callback methods
- document the expected `void` returns via phpDoc to preserve clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7bfc3efe08321b708654a26afad39